### PR TITLE
Fixed missing flag for sph2pipe in wav.scp creation

### DIFF
--- a/egs/callhome_diarization/v1/local/make_callhome_test.sh
+++ b/egs/callhome_diarization/v1/local/make_callhome_test.sh
@@ -23,7 +23,7 @@ fi
 mkdir -p $dir
 
 # Create wav.scp
-ls $1 | cut -f1 -d'.' | awk '{printf("%s '$sph2pipe' -f wav '$1'/%s.sph |\n", $1, $1)}' > $dir/wav.scp
+ls $1 | cut -f1 -d'.' | awk '{printf("%s '$sph2pipe' -f wav -p '$1'/%s.sph |\n", $1, $1)}' > $dir/wav.scp
 
 # Create segments, utt2spk, seg2spk, utt2num
 rm -f $dir/{segments,utt2spk,seg2spk,utt2num}


### PR DESCRIPTION
In the callhome data prep script, when creating wav.scp, sph2pipe was missing a flag to force conversion to 16-bit linear pcm, necessary for extracting features.
